### PR TITLE
Revert "Fix wrong define is used in StringUtils.ToLower() (#2304)"

### DIFF
--- a/Src/Newtonsoft.Json/Utilities/StringUtils.cs
+++ b/Src/Newtonsoft.Json/Utilities/StringUtils.cs
@@ -195,7 +195,7 @@ namespace Newtonsoft.Json.Utilities
 
         private static char ToLower(char c)
         {
-#if HAVE_CHAR_TO_LOWER_WITH_CULTURE
+#if HAVE_CHAR_TO_STRING_WITH_CULTURE
             c = char.ToLower(c, CultureInfo.InvariantCulture);
 #else
             c = char.ToLowerInvariant(c);


### PR DESCRIPTION
This reverts commit 666d9760719e5ec5b2a50046f7dbd6a1267c01c6.